### PR TITLE
Resolve 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.7.4
 MAINTAINER bbarber@bpl.org
 
 ENV LANG=C.UTF-8 \
-    BUNDLER_VERSION=2.2.23
+    BUNDLER_VERSION=2.2.24
 
 RUN apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \

--- a/app/models/ark_minter.rb
+++ b/app/models/ark_minter.rb
@@ -23,10 +23,6 @@ class ArkMinter < Noid::Rails::Minter::Db
     end.resume
   end
 
-  def current_arks
-    Rails.cache.fetch(['current_arks', Ark.count], expires_in: 5.minutes) { Ark.unscoped.select(:noid).distinct.all }
-  end
-
   protected
 
   def next_id
@@ -34,7 +30,6 @@ class ArkMinter < Noid::Rails::Minter::Db
     locked_inst = instance
     locked_inst.with_lock do
       minter = Noid::Minter.new(deserialize(locked_inst))
-      minter.seed(Process.pid)
       id = minter.mint
       serialize(locked_inst, minter)
     end
@@ -75,6 +70,6 @@ class ArkMinter < Noid::Rails::Minter::Db
   private
 
   def identifier_in_use?(id)
-    Noid::Rails.config.identifier_in_use.call(id, current_arks)
+    Noid::Rails.config.identifier_in_use.call(id)
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,7 +27,9 @@ nakayoshi_fork
 
 # Best Practice is to reconnect any Non Active Record Connections on boot in clustered mode
 on_worker_boot do
-  Rails.cache.redis.reload(&:quit) if Rails.cache.respond_to?(:redis)
+  if defined?(Rails)
+    Rails.cache.redis.reload(&:quit) if Rails.cache.respond_to?(:redis)
+  end
 end
 
 if %w(staging production).member?(rails_env)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: bostonlibrary/ark-manager:dev-latest
     volumes:
        - .:/ark-manager-app
     ports:

--- a/spec/models/ark_minter_spec.rb
+++ b/spec/models/ark_minter_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ArkMinter, type: :model do
+  describe 'Class' do
+    subject { described_class }
+
+    it { is_expected.to be <= Noid::Rails::Minter::Db }
+  end
+
+  describe 'Instance' do
+    subject { described_class.new }
+
+    it { is_expected.to respond_to(:namespace, :template, :default_namespace, :mint, :read) }
+    it { is_expected.to respond_to(:write!).with(1).argument }
+
+    it 'expects the default namespace to equal the config namespace' do
+      expect(subject.default_namespace).to eq(Noid::Rails.config.namespace)
+    end
+
+    it 'expects to #mint to produce a string' do
+      expect(subject.mint).to be_a_kind_of(String)
+    end
+  end
+end

--- a/spec/models/ark_spec.rb
+++ b/spec/models/ark_spec.rb
@@ -43,6 +43,23 @@ RSpec.describe Ark, type: :model do
     end
   end
 
+  describe 'Class Methods' do
+    subject { described_class }
+
+    it { is_expected.to respond_to(:current_noids_for_minter) }
+
+    let!(:arks) { create_list(:ark, 3) }
+
+    describe '.current_noids_for_minter' do
+      subject { described_class.current_noids_for_minter }
+
+      let(:expected_noids) { arks.pluck(:noid) }
+
+      it { is_expected.to be_a_kind_of(Array) }
+      it { is_expected.to match_array(expected_noids) }
+    end
+  end
+
   describe 'Scopes' do
     let!(:namespace_ark) { 'bpl-dev' }
     let!(:parent_id) { "#{namespace_ark}:3214dde845" }
@@ -50,7 +67,7 @@ RSpec.describe Ark, type: :model do
     let!(:identifier_type) { 'filename' }
     let!(:noid) { '644529e066' }
 
-    specify { expect(described_class).to respond_to(:active) }
+    specify { expect(described_class).to respond_to(:active, :minter_select) }
     specify { expect(described_class).to respond_to(:with_parent).with(1).argument }
     specify { expect(described_class).to respond_to(:with_local_id, :object_in_view).with(2).arguments }
     specify { expect(described_class).to respond_to(:with_parent_and_local_id).with(3).arguments }
@@ -99,6 +116,14 @@ RSpec.describe Ark, type: :model do
       subject { described_class.object_in_view(namespace_ark, noid).to_sql }
 
       let!(:expected_sql) { described_class.active.merge(described_class.where(namespace_ark: namespace_ark, noid: noid)).to_sql }
+
+      it { is_expected.to eq(expected_sql) }
+    end
+
+    describe '#minter_select' do
+      subject { described_class.minter_select.to_sql }
+
+      let!(:expected_sql) { described_class.select(:noid, :updated_at, :created_at).to_sql }
 
       it { is_expected.to eq(expected_sql) }
     end


### PR DESCRIPTION
- Added a more efficient way for checking for existing `noids` by `pluck`ing and caching all the `noids` in an array and checking if that value is included? during the `mint` process
- Added clause to puma `on_worker_boot` to see if `Rails` is `defined?` before reloading the cache connection to redis.  There have been a few rare cases where I have seen this not being defined and throwing an error.
- Added `image` tag to `docker-compose` to allow building and pushing new images to docker hub manually
- Bumped `$BUNDLER_VERSION` to `2.2.24` in the Dockerfile
- Added a spec for the `ArkMinter` class to (Hopefully) increase code coverage