### PR TITLE
Cache preview images and additional tuning 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem 'factory_bot_rails', '~> 6.2'
   gem 'faker', '~> 2.18'
   gem 'pry', '~> 0.13.1'
+  gem 'pry-rails'
   gem 'rspec-rails', '~> 5.0'
   gem 'rswag-specs', '~> 2.4'
   gem 'rubocop', '~> 0.75.1', require: false

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -71,13 +71,13 @@ class PreviewController < ApplicationController
 
     handle_preview_service_error!(image_data_resp) if image_data_resp.failure?
 
-    send_image(filename, image_data_resp.result.path)
+    send_image(filename, image_data_resp.result)
   end
 
   private
 
   def send_icon(filename)
-    expires_in 1.week, public: true, 's-maxage': 1.week, 'no-transform': true
+    expires_in 1.month, public: true, 's-maxage': 1.month, 'no-transform': true
 
     send_file DEFAULT_ICON_FILEPATH,
               :filename => "#{filename}.png",
@@ -86,7 +86,7 @@ class PreviewController < ApplicationController
   end
 
   def send_image(filename, file_path)
-    expires_in 12.hours, public: true, 's-maxage': 12.hours, 'no-transform': true
+    expires_in 2.weeks, public: true, 's-maxage': 2.weeks, 'no-transform': true
 
     send_file file_path,
               :filename => "#{filename}.jpg",

--- a/app/models/ark.rb
+++ b/app/models/ark.rb
@@ -54,6 +54,12 @@ class Ark < ApplicationRecord
     end
   end
 
+  def self.identifier_in_use?(noid)
+    Rails.cache.fetch([minter_exists_scope, noid, 'identifier_in_use'], expires_in: 24.hours) do
+      minter_exists_scope.exists?(noid: noid)
+    end
+  end
+
   def to_s
     Oj.dump(as_json, indent: 2)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,15 +22,6 @@ module ArkHandler
 
     config.action_dispatch.default_headers['X-Frame-Options'] = 'DENY'
 
-    if Rails.env.development?
-      console do
-        require 'pry' unless defined? Pry
-        require 'awesome_print'
-        AwesomePrint.pry!
-        config.console = Pry
-      end
-    end
-
     config.generators do |g|
       g.orm :active_record
       g.api_only = true

--- a/config/initializers/noid-rails.rb
+++ b/config/initializers/noid-rails.rb
@@ -19,6 +19,6 @@ Rails.application.reloader.to_prepare do
     config.template = '.reeddeeddk'
     config.namespace = ENV.fetch('ARK_MANAGER_DEFAULT_NAMESPACE') { Rails.application.credentials.dig(:ark, :default_namespace) || raise('no value for default ark namespace found!') }
     config.minter_class = ArkMinter
-    config.identifier_in_use = ->(noid) { Ark.minter_exists_scope.exists?(noid: noid) }
+    config.identifier_in_use = ->(noid) { Ark.identifier_in_use?(noid) }
   end
 end

--- a/lib/tasks/arks.rake
+++ b/lib/tasks/arks.rake
@@ -13,4 +13,13 @@ namespace :arks do
 
     puts 'Import task complete!'
   end
+
+  desc 'Clean images from Preview Cache'
+  task :preview_cache_purge => :environment do
+    puts 'Staring preview image cache purge!'
+
+    Scripts.run_preview_cache_clean!
+
+    puts 'Cache purge complete!'
+  end
 end

--- a/spec/services/image_content_service_spec.rb
+++ b/spec/services/image_content_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ImageContentService, type: :service do
   let(:file_suffix) {  '_thumbnail' }
 
   specify { expect(described_service_class).to be_const_defined('ApplicationService') }
+  specify { expect(described_service_class).to be_const_defined('IMG_DEST_FOLDER') }
   specify { expect(described_service_class).to respond_to(:call).with(3).arguments }
 
   it_behaves_like 'service_class' do
@@ -23,7 +24,7 @@ RSpec.describe ImageContentService, type: :service do
   describe 'instance' do
     subject { described_service_class.new(filestream_attachment_name, filestream_key, file_suffix) }
 
-    it { is_expected.to respond_to(:filestream_attachment_name, :filestream_key, :file_suffix, :filestream_ark_id) }
+    it { is_expected.to respond_to(:filestream_attachment_name, :filestream_key, :file_suffix, :filestream_ark_id, :destination_path) }
   end
 
   describe 'successful #result' do
@@ -39,7 +40,7 @@ RSpec.describe ImageContentService, type: :service do
     end
 
     it 'Expects the #result to have the correct value' do
-      expect(subject.result).to be_a_kind_of(Tempfile)
+      expect(subject.result).to be_a_kind_of(String)
     end
   end
 


### PR DESCRIPTION
- Modified `ImageContentService` to cache retrieved files in the `Rails` app's `/tmp/cache` directory(Required for nginx)

- Added rake task to purge preview image cache(cron task needed for this)

Added an `identifer_in_use` class method that stores existing identifier queries in the `redis` cache for 24 hours

re added `pry-rails`